### PR TITLE
Implement interactive roadmap skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "clsx": "^2.1.1",
     "d3-force": "^3.0.0",
     "fuse.js": "^7.1.0",
+    "reactflow": "^11.10.0",
     "nanostores": "^1.0.1",
     "postcss": "^8.5.3",
     "react": "^19.1.0",

--- a/src/components/roadmap/InteractiveRoadmap.tsx
+++ b/src/components/roadmap/InteractiveRoadmap.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import ReactFlow, { Background, Controls, MiniMap, Node, Edge } from 'reactflow';
+import 'reactflow/dist/style.css';
+
+export interface Props {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export default function InteractiveRoadmap({ nodes, edges }: Props) {
+  const flowNodes = useMemo(() => nodes, [nodes]);
+  const flowEdges = useMemo(() => edges, [edges]);
+
+  return (
+    <div className="w-full h-[600px] rounded-lg border border-primary bg-surface-secondary/20">
+      <ReactFlow nodes={flowNodes} edges={flowEdges} fitView>
+        <Background gap={16} color="var(--color-border-primary)" />
+        <Controls />
+        <MiniMap />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/src/content/posts/_templates/roadmap.mdx
+++ b/src/content/posts/_templates/roadmap.mdx
@@ -1,0 +1,23 @@
+---
+title: "Roadmap Item Title"
+slug: "roadmap-item-slug"
+date: 2024-01-01
+excerpt: "Short summary of this roadmap milestone."
+types: ["roadmap"]
+category: "Research"
+tags: ["Milestone"]
+status: "planned"
+roadmap:
+  phase: 0
+  # optional manual positions
+  x: 0
+  y: 0
+  dependencies: []
+project:
+  area: "General"
+display:
+  showToc: true
+  accent: "blue"
+---
+
+Write your milestone content here.

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -1,0 +1,53 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  data: CollectionEntry<'posts'>;
+  position: { x: number; y: number };
+  className?: string;
+}
+
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+}
+
+/**
+ * Build roadmap graph data from posts collection.
+ */
+export async function getRoadmapGraph() {
+  const posts = await getCollection('posts');
+  const roadmapPosts = posts.filter(p => p.data.types.includes('roadmap'));
+
+  const nodes: GraphNode[] = roadmapPosts.map(post => {
+    const phase = post.data.roadmap?.phase ?? 0;
+    const index = roadmapPosts.filter(p => (p.data.roadmap?.phase ?? 0) === phase).indexOf(post);
+    const x = post.data.roadmap?.x ?? phase * 300;
+    const y = post.data.roadmap?.y ?? 100 + index * 150;
+
+    const className = post.data.status;
+    return {
+      id: post.data.slug,
+      label: post.data.title,
+      data: post,
+      position: { x, y },
+      className,
+    };
+  });
+
+  const edges: GraphEdge[] = [];
+  roadmapPosts.forEach(post => {
+    const deps = post.data.roadmap?.dependencies || [];
+    deps.forEach(dep => {
+      edges.push({
+        id: `${dep}->${post.data.slug}`,
+        source: dep,
+        target: post.data.slug,
+      });
+    });
+  });
+
+  return { nodes, edges, posts: roadmapPosts };
+}

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -1,13 +1,11 @@
 ---
 import Layout from "../../layouts/Layout.astro";
-import RoadmapVisualization from "../../components/roadmap/RoadmapVisualization.astro";
-import { getPostsByType } from "../../utils/content";
+import InteractiveRoadmap from "../../components/roadmap/InteractiveRoadmap.tsx";
+import { getRoadmapGraph } from "../../lib/roadmap";
 
-const roadmapPosts = await getPostsByType("roadmap");
+const { posts: roadmapPosts, nodes, edges } = await getRoadmapGraph();
 const introPost = roadmapPosts.find((p) => p.data.slug === "introduction");
-const milestonePosts = roadmapPosts.filter(
-  (p) => p.data.slug !== "introduction"
-);
+const milestonePosts = roadmapPosts.filter(p => p.data.slug !== "introduction");
 ---
 
 <Layout
@@ -63,7 +61,12 @@ const milestonePosts = roadmapPosts.filter(
       <!-- Roadmap Visualization -->
       <div class="mb-12">
         <h2 class="text-2xl font-semibold text-primary mb-6">The Journey</h2>
-        <RoadmapVisualization posts={milestonePosts} />
+        <InteractiveRoadmap client:visible nodes={nodes} edges={edges} />
+        <ol class="sr-only">
+          {milestonePosts.map(post => (
+            <li><a href={`/posts/${post.data.slug}`}>{post.data.title}</a></li>
+          ))}
+        </ol>
       </div>
 
       <!-- Legend -->


### PR DESCRIPTION
## Summary
- add React Flow dependency
- build roadmap graph extraction
- add interactive roadmap island
- wire new roadmap page with fallback list
- provide roadmap post template

## Testing
- `pnpm run build` *(fails: cannot resolve 'reactflow')*
- `npx astro check` *(fails: cannot find module 'reactflow')*

------
https://chatgpt.com/codex/tasks/task_e_683f5a2e28288320a268f344bc9ef033